### PR TITLE
adding unit tests and renaming ASSERT_OK_AND_ASSIGN to be without the MP prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,9 +37,12 @@ set(PUBLIC_HEADERS_STATUS_MACROS
 )
 
 add_library(absl_status_macros STATIC ${SOURCES_ABSL_STATUS_MACROS})
-target_link_libraries(absl_status_macros PUBLIC absl::memory absl::status absl::strings)
+target_link_libraries(absl_status_macros PUBLIC absl::memory absl::status absl::statusor absl::strings)
 set_target_properties(absl_status_macros PROPERTIES PUBLIC_HEADER ${PUBLIC_HEADERS_STATUS_MACROS})
 install(TARGETS absl_status_macros
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/absl_status_macros
 )
+
+# abseil status macros unit tests.
+add_subdirectory(tests)

--- a/absl_status_macros/status_matchers.h
+++ b/absl_status_macros/status_matchers.h
@@ -259,8 +259,8 @@ StatusIsMatcher StatusIs(CodeMatcher code_matcher) {
 #define STATUS_MACROS_IMPL_CONCAT_INNER_(x, y) x##y
 #define STATUS_MACROS_IMPL_CONCAT_(x, y) STATUS_MACROS_IMPL_CONCAT_INNER_(x, y)
 
-#undef MP_ASSERT_OK_AND_ASSIGN
-#define MP_ASSERT_OK_AND_ASSIGN(lhs, rexpr)                                    \
+#undef ASSERT_OK_AND_ASSIGN
+#define ASSERT_OK_AND_ASSIGN(lhs, rexpr)                                    \
   MP_ASSERT_OK_AND_ASSIGN_IMPL_(                                               \
       STATUS_MACROS_IMPL_CONCAT_(_status_or_value, __LINE__), lhs, rexpr)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,18 @@
+# GoogleTest (unit tests).
+FetchContent_Declare(
+        gtest
+        SYSTEM
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG v1.13.0
+)
+FetchContent_MakeAvailable(gtest)
+include(GoogleTest)
+
+add_executable(abseil_status_macros_tests
+        "status_macros_test.cc"
+)
+
+target_link_libraries(abseil_status_macros_tests PRIVATE absl_status_macros)
+target_include_directories(abseil_status_macros_tests PRIVATE ${CMAKE_SOURCE_DIR})
+target_link_libraries(abseil_status_macros_tests PRIVATE GTest::gtest_main GTest::gmock)
+gtest_discover_tests(abseil_status_macros_tests)

--- a/tests/status_macros_test.cc
+++ b/tests/status_macros_test.cc
@@ -1,6 +1,6 @@
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include "status_macros.h"
+#include "absl_status_macros/status_macros.h"
 #include <gtest/gtest.h>
 
 // Returns status1 if it is an error, otherwise status2


### PR DESCRIPTION
adding unit tests and renaming ASSERT_OK_AND_ASSIGN to be without the… MP (mediapipe) prefix.